### PR TITLE
Fix undefined behavior in round_block_size

### DIFF
--- a/tlsf.c
+++ b/tlsf.c
@@ -247,8 +247,10 @@ INLINE size_t adjust_size(size_t size, size_t align)
 /* Round up to the next block size */
 INLINE size_t round_block_size(size_t size)
 {
+    if (size < BLOCK_SIZE_SMALL)
+        return size;
     size_t t = ((size_t) 1 << (log2floor(size) - SL_SHIFT)) - 1;
-    return size >= BLOCK_SIZE_SMALL ? (size + t) & ~t : size;
+    return (size + t) & ~t;
 }
 
 INLINE void mapping(size_t size, uint32_t *fl, uint32_t *sl)


### PR DESCRIPTION
When size < BLOCK_SIZE_SMALL (e.g. 24), log2floor(size) can be less than SL_SHIFT, causing the uint32_t subtraction to underflow and producing a shift exponent of 0xFFFFFFFF — undefined behavior flagged by UBSAN.

This moves the small-size guard before the shift computation so it never executes with an underflowed exponent. The old ternary already returned size unchanged for small values; the early return just prevents the dead-but-UB expression from being evaluated.

Close #7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix undefined behavior in round_block_size by returning early for sizes smaller than BLOCK_SIZE_SMALL, so we never compute a shift with an underflowed exponent. This removes the dead-but-UB expression and simplifies the rounding path for larger sizes.

<sup>Written for commit b2f657eabee842df7cfa456f4028304fcddcee08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

