### PR TITLE
Fix inconsistent zero-size and alignment semantics

### DIFF
--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -676,9 +676,8 @@ void *tlsf_aalloc(tlsf_t *t, size_t align, size_t size)
     size_t adjust = adjust_size(size, ALIGN_SIZE);
 
     if (UNLIKELY(
-            !size ||
-            ((align | size) & (align - 1)) /* align!=2**x, size!=n*align */ ||
-            align > TLSF_MAX_SIZE || sizeof(tlsf_block_t) > TLSF_MAX_SIZE ||
+            !align || (align & (align - 1)) /* align must be power of two */
+            || align > TLSF_MAX_SIZE || sizeof(tlsf_block_t) > TLSF_MAX_SIZE ||
             adjust > TLSF_MAX_SIZE - align -
                          sizeof(tlsf_block_t) /* size is too large */))
         return NULL;


### PR DESCRIPTION
tlsf_aalloc(t, align, 0) returned NULL while tlsf_malloc(t, 0) returned a minimum-sized block.  Remove the !size guard so both functions treat zero-size requests identically: allocate a unique minimum-sized block (POSIX-compatible behavior).

Drop the C11 aligned_alloc requirement that size be a multiple of align. The check (align | size) & (align - 1) rejected valid requests like tlsf_aalloc(t, 64, 100).  Replace with !align || (align & (align - 1)) which only validates that alignment is a non-zero power of two, following POSIX posix_memalign semantics (C23 also dropped this constraint).

This updates random_test to exercise arbitrary (non-multiple) sizes with tlsf_aalloc, and add zero_size_align_test covering zero-size malloc, zero-size aligned alloc, non-multiple sizes, invalid alignment rejection, and regression for multiple-of-align sizes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align tlsf_aalloc behavior with tlsf_malloc for zero-size requests and adopt POSIX alignment semantics. Zero-size aligned allocations now succeed, and sizes no longer need to be multiples of alignment.

- **Bug Fixes**
  - tlsf_aalloc(t, align, 0) returns a unique minimum-sized block instead of NULL.
  - Alignment check only requires a non-zero power of two; size % align is no longer enforced (e.g., tlsf_aalloc(t, 64, 100) is valid).
  - Header docs clarified for tlsf_aalloc/tlsf_malloc; tests updated: random_test uses non-multiple sizes and new zero_size_align_test covers zero-size, alignment rejection, and regression cases.

<sup>Written for commit 3d78b3dd96fb84d969e6cc069e4e710c93475e42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

