### PR TITLE
Eliminate branches in size-to-list mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
   build-and-test:
     needs: coding-style
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This replaces the conditional branches in round_block_size and mapping() with branch-free arithmetic using bitmask selection. Both functions are called on every malloc/free and contained 'if (size < BLOCK_SIZE_SMALL)' branch that penalizes in-order cores when allocation sizes alternate between small and large ranges.

round_block_size: when is_large=0, the rounding mask is zero, collapsing to an identity (size+0 & ~0 = size). When is_large=1, the mask is (1 << shift) - 1, identical to the original formula.

mapping: a uint32_t bitmask (all-ones for small, all-zeros for large) selects between the linear sl index (size >> ALIGN_SHIFT) and logarithmic sl index ((size >> (t - SL_SHIFT)) ^ SL_COUNT). Shift operands are clamped with & (SIZE_WIDTH-1) to avoid UB when the unused path underflows.

Bin layout, struct layout, and all external semantics are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced branches in round_block_size and mapping with branch-free bitmask selection to speed malloc/free on in-order cores. Tests now throttle tlsf_check(), add a reproducible seed, and print it; bin layout and external behavior are unchanged.

- **Refactors**
  - Branch-free handling of size < BLOCK_SIZE_SMALL in round_block_size and mapping; same rounding masks/indices; shifts clamped with __SIZE_WIDTH__ to avoid UB.

- **Bug Fixes**
  - random_test(): run tlsf_check() every ~maxitems/256 ops, add TLSF_TEST_SEED and print the seed, and keep final checks to prevent O(n^2) UBSan timeouts.
  - CI: set a 10-minute timeout for build-and-test.

<sup>Written for commit 3309740b42b12fc6c1d8db4398987ba016fc8ca0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

