### PR TITLE
Use __builtin_ctz in bitmap_ffs

### DIFF
--- a/src/tlsf.c
+++ b/src/tlsf.c
@@ -91,9 +91,8 @@ __attribute__((weak)) void *tlsf_resize(tlsf_t *t, size_t size)
 
 INLINE uint32_t bitmap_ffs(uint32_t x)
 {
-    uint32_t i = (uint32_t) __builtin_ffs((int32_t) x);
-    ASSERT(i, "no set bit found");
-    return i - 1U;
+    ASSERT(x, "no set bit found");
+    return (uint32_t) __builtin_ctz(x);
 }
 
 INLINE uint32_t log2floor(size_t x)


### PR DESCRIPTION
This replaces __builtin_ffs (1-based) minus 1 with __builtin_ctz (0-based), which maps directly to RBIT+CLZ on ARM Cortex-M4 without the extra SUB instruction that the ffs-then-subtract pattern requires.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace __builtin_ffs(x) - 1 with __builtin_ctz(x) in bitmap_ffs to return a 0-based index using fewer instructions on ARM Cortex-M4 (maps to RBIT+CLZ, avoids an extra SUB). Behavior is unchanged; we still assert when x == 0.

<sup>Written for commit 6df906455224f684b313f8ec5fe2efc7621b5f7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

