### PR TITLE
Add ASan shadow poisoning and fill-pattern instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,29 @@ jobs:
             cc: gcc
             cflags: "-fsanitize=undefined"
           - runner: ubuntu-24.04
+            cc: gcc
+            cflags: "-fsanitize=address,undefined"
+          - runner: ubuntu-24.04
             cc: clang
             cflags: ""
           - runner: ubuntu-24.04
             cc: clang
             cflags: "-fsanitize=undefined"
+          - runner: ubuntu-24.04
+            cc: clang
+            cflags: "-fsanitize=address,undefined"
+          - runner: ubuntu-24.04
+            cc: clang
+            cflags: "-fsanitize=address,undefined -DTLSF_ENABLE_POISON"
           - runner: ubuntu-24.04-arm
             cc: gcc
             cflags: ""
           - runner: ubuntu-24.04-arm
             cc: clang
             cflags: ""
+          - runner: ubuntu-24.04-arm
+            cc: gcc
+            cflags: "-fsanitize=address,undefined"
     steps:
       - uses: actions/checkout@v6
       - name: Build


### PR DESCRIPTION
Teach AddressSanitizer about TLSF's internal pool layout so it can detect use-after-free and buffer overflow within custom memory pools. Free block payloads are poisoned (excluding embedded TLSF metadata: free-list pointers and next block's prev pointer), and unpoisoned on allocation, realloc expansion, and pool growth/append.

A separate compile-time option (-DTLSF_ENABLE_POISON) fills payloads with 0xAA on alloc and 0xFF on free, catching stale-pointer bugs on bare-metal targets where sanitizers are unavailable.

Extend CI matrix with ASan+UBSan builds for gcc and clang on both x86-64 and ARM64, plus a combined ASan+POISON configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates ASan shadow poisoning into TLSF to catch use-after-free and overflows, plus an optional fill-pattern mode for bare‑metal. CI adds ASan+UBSan on x86‑64 (gcc/clang) and ARM64 (gcc), and an ASan+POISON job on x86‑64 (clang).

- **New Features**
  - ASan: poison only the safe region of free block payloads (skip TLSF metadata); unpoison on alloc/realloc and on pool init/grow/append.
  - Fill mode (-DTLSF_ENABLE_POISON): 0xAA on alloc, 0xFF on free to expose stale-pointer and uninitialized reads.

- **Migration**
  - Works automatically with -fsanitize=address; no code changes.
  - Enable fill-pattern with -DTLSF_ENABLE_POISON.

<sup>Written for commit d2ee54b6be3da4016d295e3e0b9cfd06d7ac632a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

