### PR TITLE
Add bounded-time pool reset for static pools

### DIFF
--- a/include/tlsf.h
+++ b/include/tlsf.h
@@ -128,6 +128,24 @@ size_t tlsf_append_pool(tlsf_t *tlsf, void *mem, size_t size);
 size_t tlsf_pool_init(tlsf_t *t, void *mem, size_t bytes);
 
 /**
+ * Reset a static pool to its initial state, discarding all allocations.
+ * Bounded-time bulk deallocation: clears bitmaps, recreates a single
+ * free block.  Cost is O(FL_COUNT * SL_COUNT) for the bin reset, which
+ * is fixed at compile time.
+ *
+ * Only valid for pools created with tlsf_pool_init().
+ * Does nothing for dynamic pools or uninitialized instances.
+ *
+ * WARNING: All pointers previously returned by tlsf_malloc/aalloc/realloc
+ * become invalid after reset.  Passing stale pointers to tlsf_free or
+ * tlsf_realloc causes undefined behavior (silent metadata corruption in
+ * release builds, assertion failure in debug builds).
+ *
+ * @param t The TLSF allocator instance
+ */
+void tlsf_pool_reset(tlsf_t *t);
+
+/**
  * Allocate memory from the pool.
  *
  * @param t    The TLSF allocator instance


### PR DESCRIPTION
Arena-style workloads (allocate many, discard all) currently require per-object tlsf_free() calls.  tlsf_pool_reset() clears the FL/SL bitmaps, resets bin pointers to the sentinel, and reconstructs a single free block plus sentinel -- the same layout tlsf_pool_init() produces.  Pools extended via tlsf_append_pool() retain their full expanded capacity across resets.

This also adds check_sentinel() after sentinel construction in tlsf_pool_init() for debug-mode invariant enforcement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a bounded-time bulk reset for static TLSF pools to support arena-style “allocate many, discard all” workloads. Also adds a debug sentinel check during pool initialization.

- **New Features**
  - New tlsf_pool_reset(tlsf_t*): clears FL/SL bitmaps and bins, then rebuilds a single free block + sentinel with fixed, predictable cost.
  - Works only on static pools created with tlsf_pool_init; no-op for NULL/dynamic pools. Preserves expanded capacity from tlsf_append_pool across resets.
  - Adds check_sentinel() in tlsf_pool_init for debug-mode invariant checks.

- **Migration**
  - After tlsf_pool_reset, all previously returned pointers are invalid. Do not pass them to tlsf_free or tlsf_realloc.
  - Use tlsf_pool_reset to implement arena-style “discard all” phases; no other changes required.

<sup>Written for commit 3bfefccdcd054e7286f3e15092bfd8a6ce15e3bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

